### PR TITLE
update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /target
-/Cargo.lock


### PR DESCRIPTION
添加Cargo.lock版本追踪，以保证netease-cloud-music-gtk4下载依赖时获取指定的编译版本 #7 